### PR TITLE
6章: Enumとパターンマッチング

### DIFF
--- a/ch06-00-enums/ch06-01-defining-an-enum/Cargo.toml
+++ b/ch06-00-enums/ch06-01-defining-an-enum/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch06-01-defining-an-enum"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch06-00-enums/ch06-01-defining-an-enum/src/main.rs
+++ b/ch06-00-enums/ch06-01-defining-an-enum/src/main.rs
@@ -1,0 +1,78 @@
+// enum IpAddrKing {
+//     v4,
+//     v6,
+// }
+
+// enumは種類がわかるだけで値を保持していない
+// 今までの知識ではおそらくstructを用いて以下の表現をしていたと思われる
+// struct IpAddr {
+//     kind: IpAddrKind,
+//     address: String,
+// }
+
+// let home = IpAddr {
+//     kind: IpAddrKind::V4,
+//     address: String::from("127.0.0.1"),
+// };
+
+// let loopback = IpAddr {
+//     kind: IpAddrKind::V6,
+//     address: String::from("::1"),
+// };
+
+enum IpAddrKing {
+    // 異なっても良い
+    v4(u8, u8, u8, u8),
+    v6(String),
+}
+
+struct Ipv4Addr {
+    // --snip--
+}
+struct Ipv6Addr {
+    // --snip--
+}
+
+// 構造体で値を定義したい場合は、以下のように列挙子に埋め込むことができる
+enum IpAddr {
+    V4(Ipv4Addr),
+    V6(Ipv6Addr),
+}
+
+struct QuitMessage; // ユニット構造体
+struct MoveMessage {
+    x: i32,
+    y: i32,
+}
+struct WriteMessage(String); // タプル構造体
+struct ChangeColorMessage(i32, i32, i32); // タプル構造体
+
+
+enum Message {
+    Quit(QuitMessage),
+    Move(MoveMessage),
+    Write(WriteMessage),
+    ChangeColor(ChangeColorMessage),
+}
+
+impl Message {
+    fn call(&self) {
+        // --snip--
+    }
+}
+
+fn main() {
+    // let four = IpAddrKing::v4;
+    // let six = IpAddrKing::v6;
+    // route(four);
+    // route(six);
+
+    let home = IpAddrKing::v4(127, 0, 0, 1);
+    let loopback = IpAddrKing::v6(String::from("::1"));
+    println!("Hello, world!");
+
+    let m = Message::Write(WriteMessage(String::from("hello")));
+    m.call();
+}
+
+// fn route(ip_type: IpAddrKing) {}

--- a/ch06-00-enums/ch06-02-match/Cargo.toml
+++ b/ch06-00-enums/ch06-02-match/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch06-02-match"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch06-00-enums/ch06-02-match/src/main.rs
+++ b/ch06-00-enums/ch06-02-match/src/main.rs
@@ -1,0 +1,65 @@
+#[derive(Debug)]
+enum UsState {
+    Alabama,
+    Alaska,
+    // --snip--
+}
+
+enum Coin {
+    Penny,
+    Nickel,
+    Dime,
+    Quarter(UsState),
+}
+
+fn main() {
+    // let coin = Coin::Quarter(UsState::Alaska);
+    let coin = Coin::Nickel;
+    let value = value_in_cents(&coin);
+    let five = Some(5);
+    let six = plus_one(five);
+    let none = plus_one(None);
+    println!("value in cents: {}", value);
+    println!("six: {:#?}", six);
+
+    // 一つのケースしか考慮したくない場合はif letを使う
+    let mut count = 0;
+    if let Coin::Quarter(state) = coin {
+        println!("State quarte from {:#?}", state);
+    } else {
+        count += 1;
+    }
+    println!("count: {}", count)
+}
+
+fn value_in_cents(coin: &Coin) -> u32 {
+    match coin {
+        Coin::Penny => {
+            println!("Lucky penny!");
+            1
+        },
+        Coin::Nickel => 5,
+        Coin::Dime => 10,
+        Coin::Quarter(state) => {
+            println!("State quarte from {:#?}", state);
+            25
+        },
+    }
+}
+
+fn plus_one(x: Option<i32>) -> Option<i32> {
+    match x {
+        None => None,
+        Some(i) => Some(i + 1),
+    }
+}
+
+// こんな感じで、1357の挙動しか興味ない場合は、それ以外を_でマッチさせることができる
+// let some_u8_value = 0u8;
+// match some_u8_value {
+//     1 => println!("one"),
+//     3 => println!("three"),
+//     5 => println!("five"),
+//     7 => println!("seven"),
+//     _ => (),
+// }


### PR DESCRIPTION
- enumは性質上違う値の型を持つので、その値ごとの処理を書きたいときに `match` はよく使う
- 1つの値だけ見たい時は `if let`