### PR TITLE
11章: 自動テストを書く

### DIFF
--- a/ch05-00-structs/adder/Cargo.toml
+++ b/ch05-00-structs/adder/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "adder"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch05-00-structs/adder/src/lib.rs
+++ b/ch05-00-structs/adder/src/lib.rs
@@ -1,0 +1,17 @@
+pub fn add_two(a: i32) -> i32 {
+    internal_adder(a, 2)
+}
+
+fn internal_adder(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal() {
+        assert_eq!(4, internal_adder(2, 2));
+    }
+}

--- a/ch05-00-structs/adder/tests/common/mod.rs
+++ b/ch05-00-structs/adder/tests/common/mod.rs
@@ -1,0 +1,3 @@
+pub fn setup() {
+  // setup code specific to your library's tests would go here
+}

--- a/ch05-00-structs/adder/tests/dummycommon/mod.rs
+++ b/ch05-00-structs/adder/tests/dummycommon/mod.rs
@@ -1,0 +1,4 @@
+pub fn setup() {
+  // setup code specific to your library's tests would go here
+  println!("setup");
+}

--- a/ch05-00-structs/adder/tests/hoge_test.rs
+++ b/ch05-00-structs/adder/tests/hoge_test.rs
@@ -1,0 +1,12 @@
+extern crate adder;
+// tests ディレクトリのテストは、個別のクレートであるため、各ライブラリをこの形式でimportする必要がある
+// 
+
+mod dummycommon;
+// commonモジュールをインポートする
+
+#[test]
+fn it_adds_two() {
+  dummycommon::setup();
+    assert_eq!(4, adder::add_two(2));
+}

--- a/ch05-00-structs/adder/tests/integration_test.rs
+++ b/ch05-00-structs/adder/tests/integration_test.rs
@@ -1,0 +1,12 @@
+extern crate adder;
+// tests ディレクトリのテストは、個別のクレートであるため、各ライブラリをこの形式でimportする必要がある
+// 
+
+mod common;
+// commonモジュールをインポートする
+
+#[test]
+fn it_adds_two() {
+  common::setup();
+    assert_eq!(4, adder::add_two(2));
+}

--- a/ch11-00-testing/ch11-01-writing-tests/Cargo.toml
+++ b/ch11-00-testing/ch11-01-writing-tests/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch11-01-writing-tests"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch11-00-testing/ch11-01-writing-tests/src/lib.rs
+++ b/ch11-00-testing/ch11-01-writing-tests/src/lib.rs
@@ -1,0 +1,106 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+pub fn add_two(a: i32) -> i32 {
+    a + 2
+}
+
+#[derive(Debug)]
+struct Rectangle {
+    width: u32,
+    height: u32,
+}
+
+impl Rectangle {
+    fn can_hold(&self, other: &Rectangle) -> bool {
+        self.width > other.width && self.height > other.height
+    }
+}
+
+pub fn greeting(name: &str) -> String {
+    format!("Hello {}!", name)
+}
+
+pub struct Guess {
+    value: i32
+}
+
+impl  Guess {
+    pub fn new(value: i32) -> Guess {
+        if value < 1 {
+            panic!(
+                //予想値は1以上でなければなりませんが、{}でした。
+                "Guess value must be greater than or equal to 1, got {}.",
+                value
+            );
+        } else if value > 100 {
+            panic!(
+                //予想値は100以下でなければなりませんが、{}でした。
+                "Guess value must be less than or equal to 100, got {}.",
+                value
+            );
+        }
+
+        Guess { value }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exploration() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+
+    #[test]
+    fn larger_can_hold_smaller() {
+        let larger = Rectangle {
+            width: 8,
+            height: 7,
+        };
+        let smaller = Rectangle {
+            width: 5,
+            height: 1,
+        };
+        assert!(larger.can_hold(&smaller));
+    }
+
+    #[test]
+    fn smaller_cannot_hold_larger() {
+        let larger = Rectangle {
+            width: 8,
+            height: 7,
+        };
+        let smaller = Rectangle {
+            width: 5,
+            height: 1,
+        };
+        assert!(!smaller.can_hold(&larger));
+    }
+
+    #[test]
+    fn it_adds_two() {
+        assert_eq!(4, add_two(2))
+    }
+
+    #[test]
+    fn greeting_contains_name() {
+        let result = greeting("Carol");
+        assert!(
+            result.contains("Carol"),
+            "Greeting did not contain name, value was `{}`", 
+            result
+        )
+    }
+
+    #[test]
+    #[should_panic(expected = "Guess value must be less than or equal to 100")]
+    fn greater_than_100() {
+        Guess::new(200);
+    }
+}


### PR DESCRIPTION
- `cargo test` でテストを実行する
- tests/integration_test.rs で結合テストを実行する
  - ただし、testsディレクトリ配下のファイルの命名は別でも良い( `tests/hoge_test.rs` でも動く )
  - testディレクトリ配下で結合テストの実行ファイルをまとめるものだと思う
- setupなどの共通関数は、 `test/common/` 配下にまとめる
  - ただし、 `test/common/` という命名が必須というわけではなく、そういったまとめ方をする、のが一般的なのかな？
  - 実際に、 `test/dummycommon/` でも共通関数の定義はできた
- `cargo test -- --nocapture` でprintInの出力も端末に表示できる