### PR TITLE
15章: スマートポインタ

### DIFF
--- a/ch15-00-smart-pointers/ch15-01-box/Cargo.toml
+++ b/ch15-00-smart-pointers/ch15-01-box/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch15-01-box"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch15-00-smart-pointers/ch15-01-box/src/main.rs
+++ b/ch15-00-smart-pointers/ch15-01-box/src/main.rs
@@ -1,0 +1,17 @@
+use List::{Cons, Nil};
+
+fn main() {
+    // Boxはスタックに格納され、ヒープに格納されたデータへのポインタを保持する
+    // mainの終わりで、ボックスはメモリから解放される(メモリの解放はボックスとヒープに格納されている値の両方に対して行われる)
+    let b = Box::new(5);
+    println!("b = {}", b);    
+    let list = Cons(1, Box::new(Cons(2, Box::new(Cons(3, Box::new(Nil))))));
+}
+
+
+enum List {
+    // Boxは参照を保持するので、Listのサイズがわかるようになる
+    // 間接参照という
+    Cons(i32, Box<List>),
+    Nil
+}

--- a/ch15-00-smart-pointers/ch15-02-deref/Cargo.toml
+++ b/ch15-00-smart-pointers/ch15-02-deref/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch15-02-deref"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch15-00-smart-pointers/ch15-02-deref/src/main.rs
+++ b/ch15-00-smart-pointers/ch15-02-deref/src/main.rs
@@ -1,0 +1,39 @@
+use std::ops::Deref;
+
+fn main() {
+    let m = MyBox::new(String::from("Rust"));
+    // derefを呼び出すことで、 &MyBox<String>を&Stringに変換できる
+    hello(&m);
+
+    let x = 5;
+    // let y = &x;
+    // 上記は以下のように書き換えられる
+    // let y = Box::new(x);
+
+    let y = MyBox::new(x);
+
+    assert_eq!(5, x);
+    // この時、実際はこのコードを走らせている
+    // *(y.deref())
+    // Derefトレイトを実装しているので、以下のように書ける
+    assert_eq!(5, *y);
+}
+
+struct MyBox<T>(T);
+
+impl<T> Deref for MyBox<T>  {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+impl<T> MyBox<T>  {
+    fn new(x: T) -> MyBox<T> {
+        MyBox(x)
+    }
+}
+
+fn hello(name: &str) {
+    println!("Hello, {}", name)
+}

--- a/ch15-00-smart-pointers/ch15-03-drop/Cargo.toml
+++ b/ch15-00-smart-pointers/ch15-03-drop/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch15-03-drop"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch15-00-smart-pointers/ch15-03-drop/src/main.rs
+++ b/ch15-00-smart-pointers/ch15-03-drop/src/main.rs
@@ -1,0 +1,16 @@
+struct CustomSmartPointer {
+    data: String
+}
+
+impl Drop for CustomSmartPointer {
+    fn drop(&mut self) {
+        println!("Dropping CustomSmartPointer with data `{}`!", self.data);
+    }
+}
+
+fn main() {
+    let c = CustomSmartPointer { data: String::from("my stuff")};
+    let d = CustomSmartPointer { data: String::from("other stuff")};
+    drop(c);
+    println!("CustomSmartPointers created.");
+}

--- a/ch15-00-smart-pointers/ch15-04-rc/Cargo.toml
+++ b/ch15-00-smart-pointers/ch15-04-rc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch15-04-rc"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch15-00-smart-pointers/ch15-04-rc/src/main.rs
+++ b/ch15-00-smart-pointers/ch15-04-rc/src/main.rs
@@ -1,0 +1,27 @@
+use std::rc::Rc;
+use List::{Cons, Nil};
+
+enum List {
+    Cons(i32, Rc<List>),
+    Nil,
+}
+
+fn main() {
+    
+    let a = Rc::new(Cons(5, Rc::new(Cons(10, Rc::new(Nil)))));
+
+    // a.cloneでも可能だが、データのディープコピーが発生する
+    // Rc::cloneは、データのディープコピーは発生せず、参照カウントのみ増加する
+    // a生成後のカウント = {}
+    println!("count after creating a = {}", Rc::strong_count(&a));
+    let b = Cons(3, Rc::clone(&a));
+    // b生成後のカウント = {}
+    println!("count after creating b = {}", Rc::strong_count(&a));
+    {
+        let c = Cons(4, Rc::clone(&a));
+        // c生成後のカウント = {}
+        println!("count after creating c = {}", Rc::strong_count(&a));
+    }
+    // cがスコープを抜けた後のカウント = {}
+    println!("count after c goes out of scope = {}", Rc::strong_count(&a));
+}

--- a/ch15-00-smart-pointers/ch15-05-interior-mutability/Cargo.toml
+++ b/ch15-00-smart-pointers/ch15-05-interior-mutability/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch15-05-interior-mutability"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch15-00-smart-pointers/ch15-05-interior-mutability/src/lib.rs
+++ b/ch15-00-smart-pointers/ch15-05-interior-mutability/src/lib.rs
@@ -1,0 +1,70 @@
+pub trait Messenger {
+  fn send(&self, msg: &str);
+}
+
+pub struct LimitTracker<'a, T: 'a + Messenger> {
+  messenger: &'a T,
+  value: usize,
+  max: usize,
+}
+
+impl<'a, T> LimitTracker<'a, T>
+  where T: Messenger {
+  pub fn new(messenger: &T, max: usize) -> LimitTracker<T> {
+    LimitTracker { messenger: messenger, value: 0, max }
+  }
+
+  pub fn set_value(&mut self, value:usize) {
+    self.value = value;
+    
+    let percentage_of_max = self.value as f64 / self.max as f64;
+
+    if percentage_of_max >= 0.75 && percentage_of_max < 0.9 {
+        self.messenger.send("Warning: You've used up over 75% of your quota!");
+    } else if percentage_of_max >= 0.9 && percentage_of_max < 1.0 {
+        self.messenger.send("Urgent warning: You've used up over 90% of your quota!");
+    } else if percentage_of_max >= 1.0 {
+        self.messenger.send("Error: You are over your quota!");
+    }
+  }
+}
+
+
+#[cfg(test)]
+mod tests {
+  use std::cell::RefCell;
+
+use super::*;
+
+  struct MockMessenger {
+    // sent_messages: Vec<String>,
+    sent_messages: RefCell<Vec<String>>
+  }
+
+  impl MockMessenger {
+    fn new() -> MockMessenger {
+      MockMessenger { sent_messages: RefCell::new(vec![]) }
+    }
+  }
+
+  impl Messenger for MockMessenger {
+    fn send(&self, msg: &str) {
+      self.sent_messages.borrow_mut().push(String::from(msg));
+      // let mut one_borrow = self.sent_messages.borrow_mut();
+      // let mut two_borrow = self.sent_messages.borrow_mut();
+
+      // one_borrow.push(String::from("hello"));
+      // two_borrow.push(String::from("hello"));
+    }
+
+  }
+  #[test]
+  fn it_sends_an_over_75_percent_warning_message() {
+    let mock_messenger = MockMessenger::new();
+    let mut limit_tracker = LimitTracker::new(&mock_messenger, 100);
+
+    limit_tracker.set_value(100);
+
+    assert_eq!(mock_messenger.sent_messages.borrow().len(), 1);
+  }
+}

--- a/ch15-00-smart-pointers/ch15-05-interior-mutability/src/main.rs
+++ b/ch15-00-smart-pointers/ch15-05-interior-mutability/src/main.rs
@@ -1,0 +1,31 @@
+use std::{rc::Rc, cell::RefCell};
+
+#[derive(Debug)]
+enum List {
+    Cons(Rc<RefCell<i32>>, Rc<List>),
+    Nil
+}
+
+use List::{Cons, Nil};
+
+fn main() {
+    // 複数人所有できるようRc::newする
+    // かつ不変な値を可変にしたいので、RefCell::newで値を生成する
+    let value = Rc::new(RefCell::new(5));
+
+    // 所有者が増える際はRc::cloneを利用する
+    // valueの所有者が増えた
+    let a = Rc::new(Cons(Rc::clone(&value), Rc::new(Nil)));
+
+    // b, cはvalueを所有するaを所有する
+    let b = Cons(Rc::new(RefCell::new(6)), Rc::clone(&a));
+    let c = Cons(Rc::new(RefCell::new(10)), Rc::clone(&a));
+
+    // 可変借用し、valueの値を変更する
+    *value.borrow_mut() += 10;
+
+    println!("a after = {:?}", a);
+    // b, cは変更されたvalueへの参照を持つので、b, c の値も5 + 10の15を保持する
+    println!("b after = {:?}", b);
+    println!("c after = {:?}", c);
+}

--- a/ch15-00-smart-pointers/ch15-06-reference-cycles/Cargo.toml
+++ b/ch15-00-smart-pointers/ch15-06-reference-cycles/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch15-06-reference-cycles"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch15-00-smart-pointers/ch15-06-reference-cycles/src/main.rs
+++ b/ch15-00-smart-pointers/ch15-06-reference-cycles/src/main.rs
@@ -1,0 +1,49 @@
+use std::{cell::RefCell, rc::Rc};
+use List::{Cons, Nil};
+
+#[derive(Debug)]
+enum List {
+    Cons(i32, RefCell<Rc<List>>),
+    Nil
+}
+
+impl List {
+    fn tail(&self) -> Option<&RefCell<Rc<List>>> {
+        match *self {
+            Cons(_, ref item) => Some(item),
+            Nil => None
+        }
+    }
+}
+
+fn main() {
+    let a = Rc::new(Cons(5, RefCell::new(Rc::new(Nil))));
+
+    // aの最初の参照カウント = {}
+    println!("a initial rc count = {}", Rc::strong_count(&a));
+    // aの次の要素は = {:?}
+    println!("a next item = {:?}", a.tail());
+
+    let b = Rc::new(Cons(10, RefCell::new(Rc::clone(&a))));
+
+    // b作成後のaの参照カウント = {}
+    println!("a rc count after b creation = {}", Rc::strong_count(&a));
+    // bの最初の参照カウント = {}
+    println!("b initial rc count = {}", Rc::strong_count(&b));
+    // bの次の要素 = {:?}
+    println!("b next item = {:?}", b.tail());
+
+    if let Some(link) = a.tail() {
+        *link.borrow_mut() = Rc::clone(&b);
+    }
+
+    // aを変更後のbの参照カウント = {}
+    println!("b rc count after changing a = {}", Rc::strong_count(&b));
+    // aを変更後のaの参照カウント = {}
+    println!("a rc count after changing a = {}", Rc::strong_count(&a));
+
+    // Uncomment the next line to see that we have a cycle;
+    // it will overflow the stack
+    // 次の行のコメントを外して循環していると確認してください; スタックオーバーフローします
+    // println!("a next item = {:?}", a.tail());        // aの次の要素 = {:?}
+}


### PR DESCRIPTION
- Box<T> を使ってヒープにデータを格納する
  - ListにList（自身）を格納したい時、参照だけ保持するようにして、コンパイラが値を格納するのに必要なサイズを算出可能にする
  - 参照ではなく実データを保持するようにしてしまうと、コンパイラが、どれだけサイズを確保すればいいかわからずエラーになってしまう
- Dropトレイトでdrop時に任意のコードを実行することができる
- RcとRefCellあたりの理解が浅いので、ここは再度学ぶ必要ある