### PR TITLE
16章: 恐れるな！並行性

### DIFF
--- a/ch16-00-concurrency/ch16-01-threads/Cargo.toml
+++ b/ch16-00-concurrency/ch16-01-threads/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch16-01-threads"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch16-00-concurrency/ch16-01-threads/src/main.rs
+++ b/ch16-00-concurrency/ch16-01-threads/src/main.rs
@@ -1,0 +1,33 @@
+use std::{thread, time::Duration};
+
+fn main() {
+    let handle = thread::spawn(|| {
+        for i in 1..10 {
+            println!("hi number {} from the spawned thread", i);
+            thread::sleep(Duration::from_millis(1));
+        }
+    });
+    
+    // 立ち上げたスレッドの処理が完了されるまで待ってから、メインスレッドの処理に移る
+    handle.join().unwrap();
+    
+    for i in 1..5 {
+        println!("hi number {} from the main thread", i);
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    // メインスレッドの処理が完了しても、handleのスレッドの処理が終わるまでを待つ。
+    // handle.join().unwrap()
+
+
+    let v = vec![1,2,3];
+
+    // moveキーワードを使用して、所有権を移すことでコンパイルエラーが消える
+    // 所有権を新しく作成したスレッドに移さないと、メインスレッドの方で、dropなど参照している値が消える可能性がある
+    // 所有権をメインスレッドでdropなどをしてしまうと、動かなくなるので、所有権を受け取る必要がある
+    let handle2 = thread::spawn(move || {
+        print!("Here's a vector: {:?}", v);
+    });
+
+    handle2.join().unwrap()
+}

--- a/ch16-00-concurrency/ch16-02-message-passing/Cargo.toml
+++ b/ch16-00-concurrency/ch16-02-message-passing/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch16-02-message-passing"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch16-00-concurrency/ch16-02-message-passing/src/main.rs
+++ b/ch16-00-concurrency/ch16-02-message-passing/src/main.rs
@@ -1,0 +1,42 @@
+use std::{sync::mpsc, thread, time::Duration};
+// mpscはmultiple producer, single consumer
+fn main() {
+    // タプルを返し、一つ目が送信側、二つ目が受信側
+    let (tx, rx) = mpsc::channel();
+
+    // 送信側は複数持てる(multiple producer)
+    let tx2 = mpsc::Sender::clone(&tx);
+
+    thread::spawn(move || {
+        let val = String::from("hi");
+        // sendの段階で、所有権を奪い値がムーブされる(受信側が所有権を得る)
+        tx.send(val).unwrap();
+        // なので以下のコードはエラーが出る
+        // println!("value is {}", val);
+    });
+
+    // recvはスレッドの実行をブロックするので、送信側のロジックをコメントアウトしたら、送信されないためメインスレッドの処理が永遠に完了しない
+    // そしてそれ自体は何もエラーを出さないので、気付けない
+    let received = rx.recv().unwrap();
+
+    println!("Got: {}", received);
+
+
+    thread::spawn(move || {
+        let vals = vec![
+            String::from("hi"),
+            String::from("from"),
+            String::from("the"),
+            String::from("thread"),
+        ];
+
+        for val in vals {
+            tx2.send(val).unwrap();
+            thread::sleep(Duration::from_secs(1));
+        }
+    });
+
+    for received in rx {
+        println!("Got: {}", received);
+    }
+}

--- a/ch16-00-concurrency/ch16-03-shared-state/Cargo.toml
+++ b/ch16-00-concurrency/ch16-03-shared-state/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch16-03-shared-state"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch16-00-concurrency/ch16-03-shared-state/src/main.rs
+++ b/ch16-00-concurrency/ch16-03-shared-state/src/main.rs
@@ -1,0 +1,39 @@
+use std::{sync::{Mutex, Arc}, thread};
+
+fn main() {
+    // let m = Mutex::new(5);
+
+    // {
+    //     let mut num = m.lock().unwrap();
+
+    //     *num = 6
+    // }
+
+    // println!("m = {:?}", m);
+
+    // counterの所有権は複数のスレッドにムーブすることはできないので、threadに渡す際にコンパイルエラー
+    // let counter = Mutex::new(0);
+
+    let counter = Arc::new(Mutex::new(0));
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        // ArcはRcのような挙動を取り、並行な状況で安全に使用できる型
+        // スレッド間でもメモリ安全に挙動を取るのがArc。
+        // これだけ見るとArcだけでいいじゃんとなりがちだが、スレッド間でデータを共有する際の安全性を確保するには、パフォーマンスの犠牲が必要
+        // シングルスレッドで処理するならarcを強制する必要がない
+        let counter = Arc::clone(&counter);
+        let handle = thread::spawn(move || {
+            let mut num = counter.lock().unwrap();
+
+            *num += 1;
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!("Result: {}", *counter.lock().unwrap());
+}


### PR DESCRIPTION
- thread::spawnで別のスレッドを作成し、並行処理を行う
  - 別スレッドの処理を待つこともできる（ = `join()` ）
- 違うスレッド間である一つのデータを参照する際は、所有権を意識する
  -   クロージャでmoveキーワードが必要
- チャンネルを使ってメッセージの送受信をする
- Arc で複数のスレッド間において使用するデータでもメモリ安全を実現する
  - ただし、パフォーマンスを犠牲にしているため、何でもかんでもArcにすればいいわけではない
  - スレッド間でのメモリ安全性を実現するために、ロックを得るようにしているため、パフォーマンスに影響が出てしまう