### PR TITLE
17章: Rustのオブジェクト指向プログラミング機能

### DIFF
--- a/ch17-00-oop/ch17-01-what-is-oo/Cargo.toml
+++ b/ch17-00-oop/ch17-01-what-is-oo/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch17-01-what-is-oo"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch17-00-oop/ch17-01-what-is-oo/src/lib.rs
+++ b/ch17-00-oop/ch17-01-what-is-oo/src/lib.rs
@@ -1,0 +1,61 @@
+pub struct AveragedCollection {
+    list: Vec<i32>,
+    average: f64
+}
+
+impl AveragedCollection {
+    pub fn add(&mut self, value: i32) {
+        self.list.push(value);
+        self.update_average();
+    }
+
+    pub fn remove(&mut self) -> Option<i32> {
+        let result = self.list.pop();
+        match result {
+            Some(value) => {
+                self.update_average();
+                Some(value)
+            },
+            None => None
+        }
+    }
+
+    pub fn average(&self) -> f64 {
+        self.average
+    }
+
+    fn update_average(&mut self) {
+        // ここは型推論効かない
+        let total: i32 = self.list.iter().sum();
+        self.average = total as f64 / self.list.len() as f64;
+    }
+}
+
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+
+    #[test]
+    fn average_is_three_between_one_and_five() {
+        let mut collection = AveragedCollection {
+            list: vec![],
+            average: 0.0
+        };
+        collection.add(1);
+        collection.add(2);
+        collection.add(3);
+        collection.add(4);
+        collection.add(5);
+        assert_eq!(collection.average(), 3.0);
+    }
+}

--- a/ch17-00-oop/ch17-02-trait-objects/Cargo.toml
+++ b/ch17-00-oop/ch17-02-trait-objects/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch17-02-trait-objects"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch17-00-oop/ch17-02-trait-objects/src/lib.rs
+++ b/ch17-00-oop/ch17-02-trait-objects/src/lib.rs
@@ -1,0 +1,42 @@
+pub trait Draw {
+    fn draw(&self);
+}
+
+pub struct Button {
+    pub width: u32,
+    pub height: u32,
+    pub label: String,
+}
+
+impl Draw for Button {
+    fn draw(&self) {
+        println!("draw with Button!!")
+    }
+}
+
+pub struct Screen {
+    pub components: Vec<Box<dyn Draw>>,
+}
+
+impl Screen {
+    pub fn run(&self) {
+        for component in self.components.iter() {
+            component.draw();
+        }
+    }
+}
+
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/ch17-00-oop/ch17-02-trait-objects/src/main.rs
+++ b/ch17-00-oop/ch17-02-trait-objects/src/main.rs
@@ -1,0 +1,37 @@
+extern crate ch17_02_trait_objects;
+use ch17_02_trait_objects::{Draw, Button, Screen};
+
+struct SelectBox {
+  width: u32,
+  height: u32,
+  options: Vec<String>,
+}
+
+impl Draw for SelectBox {
+  fn draw(&self) {
+      println!("draw with SelectBox");
+  }
+}
+
+fn main() {
+  let screen = Screen {
+    components: vec![
+      Box::new(SelectBox {
+        width: 75,
+        height: 10,
+        options: vec![
+          String::from("Yes"),
+          String::from("maybe"),
+          String::from("no"),
+        ]
+      }),
+      Box::new(Button {
+        width: 50,
+        height: 10,
+        label: String::from("Button OK")
+      })
+    ]
+  };
+
+  screen.run();
+}

--- a/ch17-00-oop/ch17-03-oo-design-patterns/Cargo.toml
+++ b/ch17-00-oop/ch17-03-oo-design-patterns/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ch17-03-oo-design-patterns"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch17-00-oop/ch17-03-oo-design-patterns/src/lib.rs
+++ b/ch17-00-oop/ch17-03-oo-design-patterns/src/lib.rs
@@ -1,0 +1,81 @@
+trait State {
+  fn request_review(self: Box<Self>) -> Box<dyn State>;
+  fn approve(self: Box<Self>) -> Box<dyn State>;
+
+  fn content<'a>(&self, post: &'a Post) -> &'a str {
+    ""
+  }
+}
+
+struct Draft {}
+
+impl State for Draft {
+  fn request_review(self: Box<Self>) -> Box<dyn State> {
+      Box::new(PendingReview {})
+  }
+
+  fn approve(self: Box<Self>) -> Box<dyn State> {
+      self
+  }
+}
+
+struct PendingReview {}
+
+impl State for PendingReview {
+  fn request_review(self: Box<Self>) -> Box<dyn State> {
+      self
+  }
+
+  fn approve(self: Box<Self>) -> Box<dyn State> {
+    Box::new(Published {})      
+  }
+}
+
+struct Published {}
+
+impl State for Published {
+  fn request_review(self: Box<Self>) -> Box<dyn State> {
+      self
+  }
+
+  fn approve(self: Box<Self>) -> Box<dyn State> {
+    self  
+  }
+
+  fn content<'a>(&self, post: &'a Post) -> &'a str {
+      &post.content
+  }
+}
+
+pub struct Post {
+  state: Option<Box<dyn State>>,
+  content: String
+}
+
+impl Post {
+  pub fn new() -> Post {
+    Post { state: Some(Box::new(Draft {})), content: String::new() }
+  }
+
+  pub fn add_text(&mut self, text: &str) {
+    self.content.push_str(text);
+  }
+
+  pub fn request_review(&mut self) {
+    if let Some(s) = self.state.take() {
+        self.state = Some(s.request_review())
+    }
+}
+
+
+  pub fn content(&self) -> &str {
+    self.state.as_ref().unwrap().content(&self)
+  }
+
+  pub fn approve(&mut self) {
+    if let Some(s) = self.state.take() {
+      self.state = Some(s.approve())
+    }
+  }
+}
+

--- a/ch17-00-oop/ch17-03-oo-design-patterns/src/main.rs
+++ b/ch17-00-oop/ch17-03-oo-design-patterns/src/main.rs
@@ -1,0 +1,15 @@
+extern crate ch17_03_oo_design_patterns;
+use ch17_03_oo_design_patterns::Post;
+
+fn main() {
+    let mut post = Post::new();
+
+    post.add_text("I ate a salad for lunch today");
+    assert_eq!("", post.content());
+
+    post.request_review();
+    assert_eq!("", post.content());
+
+    post.approve();
+    assert_eq!("I ate a salad for lunch today", post.content());
+}


### PR DESCRIPTION
- カプセル化などは可能だし、例えばトレイトを使ってstateパターンを実装するなども可能
- ジェネリクスとトレイト境界を使って実装したい時は、ある一つの型しか許可したくない時
  - 定義したトレイトを受け取るようにしておけば、そのトレイトを実装する型ならなんでも許可される
  - vecの要素をトレイトにしたときが一番わかりやすい
    - 17.2の章