### PR TITLE
20章: 最後のプロジェクト：マルチスレッドのWebサーバを構築する

### DIFF
--- a/ch20-00-final-project-a-web-server/hello/404.html
+++ b/ch20-00-final-project-a-web-server/hello/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello!</title>
+  </head>
+  <body>
+    <!--
+ああ！
+-->
+    <h1>Oops!</h1>
+    <!--
+すいません。要求しているものが理解できません
+-->
+    <p>Sorry, I don't know what you're asking for.</p>
+  </body>
+</html>

--- a/ch20-00-final-project-a-web-server/hello/Cargo.toml
+++ b/ch20-00-final-project-a-web-server/hello/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hello"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ch20-00-final-project-a-web-server/hello/hello.html
+++ b/ch20-00-final-project-a-web-server/hello/hello.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello!</title>
+  </head>
+  <body>
+    <!--
+やあ！
+-->
+    <h1>Hello!</h1>
+    <!--
+Rustからやあ
+-->
+    <p>Hi from Rust</p>
+  </body>
+</html>

--- a/ch20-00-final-project-a-web-server/hello/src/lib.rs
+++ b/ch20-00-final-project-a-web-server/hello/src/lib.rs
@@ -1,0 +1,122 @@
+// そーいえば、structとmodの違いあまりわかっていないけど、modは単にグルーピングするためだけの用途かな？
+
+use std::{thread, sync::{mpsc, Arc, Mutex}};
+
+trait FnBox {
+  fn call_box(self: Box<Self>);
+}
+
+impl<F: FnOnce()> FnBox for F {
+  fn call_box(self: Box<Self>) {
+      (*self)()
+  }
+}
+
+pub struct ThreadPool {
+  workers: Vec<Worker>,
+  sender: mpsc::Sender<Message>
+}
+
+type Job = Box<dyn FnBox + Send + 'static>;
+
+impl ThreadPool {
+    /// 新しいThreadPoolを生成する
+    /// 
+    /// sizeがプールのスレッド数です。
+    /// 
+    /// # パニック
+    /// 
+    /// sizeが0なら、 `new` 関数はパニックします。
+    /// 
+    /// Create a new ThreadPool.
+    /// 
+    /// The size is the number of threads in the pool.
+    /// 
+    /// # Panics
+    /// 
+    /// The `new` function will panic if the size is zero.
+    pub fn new (size: usize) -> ThreadPool {
+      assert!(size > 0);
+
+      let (sender, receiver) = mpsc::channel();
+
+      let receiver = Arc::new(Mutex::new(receiver));
+
+      let mut workers = Vec::with_capacity(size);
+
+      for id in 0..size {
+        // スレッドを生成してベクタに格納する
+        // create some threas and store them in the vector
+        workers.push(Worker::new(id, Arc::clone(&receiver)));
+      }
+
+      ThreadPool {
+        workers,
+        sender
+      }
+    }
+
+    pub fn execute<F>(&self,f: F)
+      where
+          F: FnOnce() + Send + 'static,
+    {
+      let job = Box::new(f);
+      self.sender.send(Message::NewJob(job)).unwrap();
+    }
+}
+
+impl Drop for ThreadPool {
+  fn drop(&mut self) {
+      println!("Sending terminate message to all workers.");
+
+      for _ in &mut self.workers {
+        self.sender.send(Message::Terminate).unwrap();
+      }
+
+      println!("Shutting down all workers.");
+
+      for worker in &mut self.workers {
+        println!("Shutting down worker {}", worker.id);
+
+        if let Some(thread) = worker.thread.take() {
+          thread.join().unwrap();
+        }
+      }
+  }
+}
+
+struct Worker {
+  id: usize,
+  thread: Option<thread::JoinHandle<()>>
+}
+
+impl Worker {
+    fn new(id: usize, receiver: Arc<Mutex<mpsc::Receiver<Message>>>) -> Worker {
+      let thread = thread::spawn(move || {
+        loop {
+          let message = receiver.lock().unwrap().recv().unwrap();
+
+          match message {
+            Message::NewJob(job) => {
+              println!("Worker {} got a job; executing.", id);
+    
+              job.call_box();
+            },
+            Message::Terminate => {
+              println!("Worker {} was told to terminate.", id);
+
+              break;
+            }
+          }
+
+        }
+      });
+
+      Worker { id, thread: Some(thread) }
+    }
+}
+
+enum Message {
+  NewJob(Job),
+  Terminate
+}

--- a/ch20-00-final-project-a-web-server/hello/src/main.rs
+++ b/ch20-00-final-project-a-web-server/hello/src/main.rs
@@ -1,0 +1,54 @@
+extern crate hello;
+
+use std::fs::File;
+use std::io::prelude::*;
+use std::net::TcpStream;
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+use hello::ThreadPool;
+
+fn main() {
+    let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
+    let pool = ThreadPool::new(4);
+
+    for stream in listener.incoming().take(2) {
+        let stream = stream.unwrap();
+
+        pool.execute(|| {
+            handle_connection(stream);
+        });
+    }
+
+    println!("Shutting down.");
+}
+
+fn handle_connection(mut stream: TcpStream) {
+    let mut buffer = [0; 1024];
+
+    stream.read(&mut buffer).unwrap();
+
+    let get = b"GET / HTTP/1.1\r\n";
+    let sleep = b"GET /sleep HTTP/1.1\r\n";
+
+    let (status_line, filename) = if buffer.starts_with(get) {
+        ("HTTP/1.1 200 OK\r\n\r\n", "hello.html")
+    } else if buffer.starts_with(sleep) {
+        thread::sleep(Duration::from_secs(5));
+        ("HTTP/1.1 200 OK\r\n\r\n", "hello.html")
+    } else {
+        ("HTTP/1.1 404 NOT FOUND\r\n\r\n", "404.html")
+    };
+
+    let mut file = File::open(filename).unwrap();
+
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+
+    let response = format!("{}{}", status_line, contents);
+
+    stream.write(response.as_bytes()).unwrap();
+    stream.flush().unwrap();
+
+
+}


### PR DESCRIPTION
- サーバーの構築方法はざっと把握した
- トレイト境界が絡んでくるあたり、まだ理解が浅い
- unwrapは結構多用しているけど、そういうもので良いのか？チェーンさせると一行一行が長くなるし、try ~ catchでいつもエラーハンドリングしている身としては、ちょっと違和感はある
  - 同じようなこと書いている人いたけど、なぜそうなのかが読み取れなかったので、定かではない
    - ref: https://eng-blog.iij.ad.jp/archives/11405#unwrap_%e3%83%a1%e3%82%bd%e3%83%83%e3%83%89%e3%81%af%e3%81%aa%e3%82%8b%e3%81%b9%e3%81%8f%e4%bd%bf%e3%82%8f%e3%81%aa%e3%81%84%e3%81%bb%e3%81%86%e3%81%8c%e3%81%84%e3%81%84%e3%82%93%e3%81%98%e3%82%83%e3%81%aa%e3%81%84%e3%81%8b%e3%81%a8%e3%81%84%e3%81%86%e8%a9%b1
  - ここでも言及あった
    - ref: https://qiita.com/muumu/items/8cdcc79fa881912adf51#5-%E3%81%8A%E3%81%BE%E3%81%98%E3%81%AA%E3%81%84%E6%89%B1%E3%81%84%E3%81%95%E3%82%8C%E3%82%8Bunwrap
    - > 本来のエラーハンドリングを無視してエラーが起きたらプログラムを強制終了するというリスクのある書き方
    - 結構サンプルコードで使われることが多いのは、プロダクションコードではないから、手軽に実装したい、とかありそうな気はする
  - ChatGPTでも普通Result型から取り出してちゃんと適切にエラーハンドリングするのが良いよ、って言っていた
    